### PR TITLE
Update pathogen clone destination directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Plugin 'PsychoLlama/z.vim'
 
 [**Pathogen**](https://github.com/tpope/vim-pathogen)
 ```sh
-git clone https://github.com/PsychoLlama/z.vim ~/.vim/bundle/
+git clone https://github.com/PsychoLlama/z.vim ~/.vim/bundle/z.vim
 ```
 
 ## Configuration


### PR DESCRIPTION
Without this I get the following error:
```
02:16 $ git clone https://github.com/PsychoLlama/z.vim ~/.vim/bundle/
fatal: destination path '/home/vagrant/.vim/bundle' already exists and is not an empty directory.
```