### PR TITLE
Add option to set working directory

### DIFF
--- a/autoload/teleport.vim
+++ b/autoload/teleport.vim
@@ -19,7 +19,7 @@ endfunc
 
 func! s:go_to_directory(directory) abort
   let l:target = fnameescape(a:directory)
-  let l:auto_lcd = get(g:, 'teleport#set_cwd', v:false)
+  let l:auto_lcd = get(g:, 'teleport#update_cwd', v:false)
 
   execute 'edit ' . l:target
 

--- a/autoload/teleport.vim
+++ b/autoload/teleport.vim
@@ -14,5 +14,17 @@ func! teleport#(...) abort
   endif
 
   " Open the most probable match in the current pane.
-  execute 'edit ' . fnameescape(l:match)
+  call s:go_to_directory(l:match)
+endfunc
+
+func! s:go_to_directory(directory) abort
+  let l:target = fnameescape(a:directory)
+  let l:auto_lcd = get(g:, 'teleport#set_cwd', v:false)
+
+  execute 'edit ' . l:target
+
+  " Automatically set the window-relative current working directory.
+  if l:auto_lcd && getcwd() isnot# simplify(a:directory)
+    execute 'lcd ' . l:target
+  endif
 endfunc

--- a/doc/tags
+++ b/doc/tags
@@ -3,9 +3,11 @@ teleport#api#find_matches()	teleport.txt	/*teleport#api#find_matches()*
 teleport#api#query()	teleport.txt	/*teleport#api#query()*
 teleport#driver	teleport.txt	/*teleport#driver*
 teleport#path	teleport.txt	/*teleport#path*
+teleport#set_cwd	teleport.txt	/*teleport#set_cwd*
 teleport-changelog	teleport.txt	/*teleport-changelog*
 teleport-config	teleport.txt	/*teleport-config*
 teleport-functions	teleport.txt	/*teleport-functions*
+teleport-options	teleport.txt	/*teleport-options*
 teleport-overview	teleport.txt	/*teleport-overview*
 teleport.vim	teleport.txt	/*teleport.vim*
 z.lua	teleport.txt	/*z.lua*

--- a/doc/tags
+++ b/doc/tags
@@ -3,7 +3,7 @@ teleport#api#find_matches()	teleport.txt	/*teleport#api#find_matches()*
 teleport#api#query()	teleport.txt	/*teleport#api#query()*
 teleport#driver	teleport.txt	/*teleport#driver*
 teleport#path	teleport.txt	/*teleport#path*
-teleport#set_cwd	teleport.txt	/*teleport#set_cwd*
+teleport#update_cwd	teleport.txt	/*teleport#update_cwd*
 teleport-changelog	teleport.txt	/*teleport-changelog*
 teleport-config	teleport.txt	/*teleport-config*
 teleport-functions	teleport.txt	/*teleport-functions*

--- a/doc/teleport.txt
+++ b/doc/teleport.txt
@@ -81,14 +81,14 @@ OPTIONS                                                       *teleport-options*
 `teleport.vim` has optional features you can toggle. Try 'em out.
 
 Setting the current working directory~
-                                                              *teleport#set_cwd*
+                                                           *teleport#update_cwd*
 
 Setting this variable to |v:true| will change your current working directory
 automatically after navigation, but only for your current window (it won't
 affect other panes or tabs). This option is great when paired with |:grep| or
 fuzzy finders. >
 
-  let teleport#set_cwd = v:true
+  let teleport#update_cwd = v:true
 <
 The behavior is opt-in.
 
@@ -176,7 +176,7 @@ Changed:
 0.5.0 - UNRELEASED~
 
 Added:
-- New |teleport#set_cwd| option.
+- New |teleport#update_cwd| option.
 
 ==============================================================================
 vim: ft=help tw=78:

--- a/doc/teleport.txt
+++ b/doc/teleport.txt
@@ -75,6 +75,23 @@ zoxide~
   " Uses the global command "zoxide".
   let teleport#driver = 'zoxide'
 <
+------------------------------------------------------------------------------
+OPTIONS                                                       *teleport-options*
+
+`teleport.vim` has optional features you can toggle. Try 'em out.
+
+Setting the current working directory~
+                                                              *teleport#set_cwd*
+
+Setting this variable to |v:true| will change your current working directory
+automatically after navigation, but only for your current window (it won't
+affect other panes or tabs). This option is great when paired with |:grep| or
+fuzzy finders. >
+
+  let teleport#set_cwd = v:true
+<
+The behavior is opt-in.
+
 ==============================================================================
 FUNCTIONS                                                   *teleport-functions*
 
@@ -155,6 +172,11 @@ Changed:
 - Moved `zcd#` functions to the `teleport#` namespace.
 - Renamed `zcd#path` to |teleport#path| with a hard error.
 - Renamed `zcd#driver` to |teleport#driver|.
+
+0.5.0 - UNRELEASED~
+
+Added:
+- New |teleport#set_cwd| option.
 
 ==============================================================================
 vim: ft=help tw=78:


### PR DESCRIPTION
If you jump to another directory using teleport.vim AND you've got
`teleport#set_cwd` enabled, this will automatically set the current
working directory for your window.
```viml
let teleport#set_cwd = v:true
```

Closes #6.