### PR TITLE
Feature: zoxide frecency api support

### DIFF
--- a/autoload/teleport/drivers/zoxide.vim
+++ b/autoload/teleport/drivers/zoxide.vim
@@ -5,18 +5,15 @@ func! s:zoxide.is_supported() abort
   return executable('zoxide')
 endfunc
 
-func! s:zoxide.query(...) abort
-  let l:substrings = copy(a:000)
-  call map(l:substrings, 'fnameescape(v:val)')
-
-  let [l:result] = systemlist('zoxide query ' . join(l:substrings, ' '))
+func! s:zoxide.query(search) abort
+  let l:search_term = fnameescape(a:search)
+  let l:output = systemlist('zoxide query --list --score ' . l:search_term)
 
   if v:shell_error
     return []
   endif
 
-  " TODO: Support multiple results when '--score' ships (4b5f2e7)
-  return [{ 'frecency': -1, 'directory': l:result }]
+  return teleport#parse_output#zoxide(l:output)
 endfunc
 
 func! teleport#drivers#zoxide#() abort

--- a/autoload/teleport/parse_output.vim
+++ b/autoload/teleport/parse_output.vim
@@ -55,6 +55,22 @@ func! teleport#parse_output#autojump(search_term, output) abort
   return l:results
 endfunc
 
+" Sample output:
+"    5 /path/to/closest-match
+"    3 /path/to/possible-match
+"    3 /path/to/other-possible-match
+"    0 /path/to/lower-probability-match
+func! teleport#parse_output#zoxide(output) abort
+  let l:results = []
+
+  for l:line in a:output
+    let [l:frecency, l:directory] = matchlist(l:line, '\v\s*(\d+)\s+(.*)$')[1:2]
+    call add(l:results, { 'frecency': str2float(l:frecency), 'directory': l:directory })
+  endfor
+
+  return l:results
+endfunc
+
 func! s:order_by_directory_name(first, second) abort
   if a:first.directory is# a:second.directory
     return 0

--- a/autoload/teleport/tests/parse_output.vader
+++ b/autoload/teleport/tests/parse_output.vader
@@ -59,3 +59,23 @@ Execute (removes intermingled duplicates):
   call add(expected, { 'frecency': 2.0, 'directory': '/second' })
   call add(expected, { 'frecency': 1.0, 'directory': '/third' })
   AssertEqual expected, output
+
+### zoxide
+Execute (parses out the score):
+  let output = teleport#parse_output#zoxide([
+  \   '   3 /first',
+  \   '   2 /second',
+  \   '   2 /third',
+  \   '   0 /fourth',
+  \ ])
+
+  let expected = [{ 'frecency': 3.0, 'directory': '/first' }]
+  call add(expected, { 'frecency': 2.0, 'directory': '/second' })
+  call add(expected, { 'frecency': 2.0, 'directory': '/third' })
+  call add(expected, { 'frecency': 0.0, 'directory': '/fourth' })
+  AssertEqual expected, output
+
+Execute (returns an empty list when no results are found):
+  let output = teleport#parse_output#zoxide([])
+
+  AssertEqual [], output

--- a/doc/teleport.txt
+++ b/doc/teleport.txt
@@ -190,5 +190,11 @@ Added:
 Added:
 - Experimental autojump support.
 
+0.7.0 - July 8, 2020 ~
+
+Added:
+- Command completion for the zoxide driver (requires zoxide@>=0.4.2).
+- Real frecency values in the zoxide programmatic API (requires zoxide@>=0.4.2).
+
 ==============================================================================
 vim: ft=help tw=78:


### PR DESCRIPTION
Up until recently, zoxide only exposed a single search result in the `zoxide query` command, and the score was completely opaque. But they've just added support for both in v0.4.2.

The new options are `--list` and `--score`. Those allow me to fully implement command completion and reach programmatic parity with other drivers (previously `frecency` was hard-coded to `-1`).

Note: this will probably break the zoxide integration if your version is older than July 3rd of 2020.

See: https://github.com/ajeetdsouza/zoxide/blob/master/CHANGELOG.md#042---2020-07-03